### PR TITLE
Fix replies bug

### DIFF
--- a/src/verifyTweet.js
+++ b/src/verifyTweet.js
@@ -91,11 +91,13 @@ if (tweetData.edit_history_tweet_ids.length > 1) {
 }
 
 // Instructions Prompt
-const content = `Your job is to determine if a user's Twitter post meets the specified requirements. 
+const content = `Your job is to determine if a user's Twitter post meets the specified requirements.
 Provide a one-word answer: either "Yes" if the post meets all requirements or "No" if it does not.
-Be flexible with your interpretation, considering the nature of Twitter posts, which may contain slang, sarcasm, jargon, or new language, especially related to Web3, blockchain and crypto. 
-Ignore case mismatch issues unless explicitly specified. 
-Assume a positive intent of the user to meet the requirements and interpret the post generously, unless there is a clear and explicit violation of the requirements.`
+Be flexible with your interpretation, considering the nature of Twitter posts, which may contain slang, sarcasm, jargon, or new language, especially related to Web3, blockchain and crypto.
+Ignore case mismatch issues unless explicitly specified.
+The requirements may explicitly state that the post must reply to or quote a specific post referenced via URL (the post ID is contained within the URL).
+Unless explicitly specified, the post cannot be a reply to another post. However, unless otherwise specified, it can quote another post. If the post is a reply or quotes another post, you will be given the referenced post ID.
+Assume a positive intent of the user to meet the requirements and interpret the post generously, unless there is a clear violation of the requirements.`
 
 // Insert full URLs into tweet text
 const tweetText = tweetData.note_tweet?.text
@@ -106,19 +108,19 @@ const quotedTweetId = tweetData.referenced_tweets?.filter((tweet) => tweet.type 
 const repliedTweetId = tweetData.referenced_tweets?.filter((tweet) => tweet.type === 'replied_to').map((tweet) => tweet.id)
 
 // Verify the post meets the requirements
-const prompt = `The requirements are:\n"${
+const prompt = `The requirements are:\n${
   offerData.requirements
-}"\n\nThe user's post text is:\n"${
+}\n\n\nThe user's post text is:\n${
   tweetText
-}"${
+}${
   quotedTweetId?.length > 0
-    ? `\nThe post quoted/reposted another post with an id of ${quotedTweetId[0]}.`
-    : ''
+    ? `\n\n\nThe post quoted another post with an ID of ${quotedTweetId[0]}.`
+    : '\n\n\nThe post did not quote another post.'
 }${
   repliedTweetId?.length > 0
-    ? `\nThe post was a reply to a post with an id of ${repliedTweetId[0]}.`
-    : ''
-}\n\nDo you think the tweet meets the requirements?`
+    ? `\nThe post was a reply to a post with an ID of ${repliedTweetId[0]}.`
+    : '\nThe post is not a reply to another post.'
+}\n\nDo you think the post meets the requirements?`
 
 const aiRes = await Functions.makeHttpRequest({
   url: "https://api.openai.com/v1/chat/completions",

--- a/test/verifyTweet.test.ts
+++ b/test/verifyTweet.test.ts
@@ -7,7 +7,7 @@ describe('verifyTweet', () => {
     const totalOfferValue = 100*10^6
     const offerDuration = 1
     
-    const offerId = "8d5aafbd73a5473e017f309f7bad1efd8d88400dc5d3360e1a2e75d879555c3d"
+    const offerId = "2e4b79dcbde919ddf2acb198f79cbf92cfae4c201b53aeebc74afc639a9c4801"
 
     const result = await simulateScript({
       source: readFileSync('./src/verifyTweet.js', 'utf8'),


### PR DESCRIPTION
Right now it is possible for users to submit a reply instead of a direct post on their timeline. However, advertisers will be expecting the user to make a timeline post and just a reply (unless otherwise specified).